### PR TITLE
Change RPC, increase blocks in filter, remove redundant code

### DIFF
--- a/src/app/common/functions/boostFarm.ts
+++ b/src/app/common/functions/boostFarm.ts
@@ -643,6 +643,7 @@ export const getLockedBoostWithdrawalsInfo = async (farmAddress, chain) => {
 };
 
 export const getLastHarvestDateTimestamp = async (farmAddress, chain) => {
+  var startFirstTimer = performance.now()
   const abi = [
     {
       anonymous: false,
@@ -658,24 +659,19 @@ export const getLastHarvestDateTimestamp = async (farmAddress, chain) => {
       type: 'event',
     },
   ];
-
   const EthDater = require('ethereum-block-by-date');
-  const provider = getReadOnlyProvider(chain);
-  const dater = new EthDater(
-    provider, // Ethers provider, required.
-  );
-
+  const provider = await getReadOnlyProvider(chain);
   // Always start the search at the last sunday at 12pm
   const sunday = moment().startOf('week').set('hour', 12);
-  let block = await dater.getDate(
+  let block = await new EthDater(
+    provider, // Ethers provider, required.
+  ).getDate(
     sunday, // Date, required. Any valid moment.js value: string, milliseconds, Date() object, moment() object.
     true, // Block after, optional. Search for the nearest block before or after the given date. By default true.
     false, // Refresh boundaries, optional. Recheck the latest block before request. By default false.
   );
-
-  let toBlock = block.block + 1000;
+  let toBlock = block.block + 5000;
   let fromBlock = block.block;
-
   // this is the last block we will check. 
   // swap with toBlock + average amount by day to check from sunday to monday and give up
   const lastBlock = await provider.getBlockNumber();
@@ -691,11 +687,9 @@ export const getLastHarvestDateTimestamp = async (farmAddress, chain) => {
       chain,
       toBlock,
     );
-
     fromBlock = toBlock;
-    toBlock = toBlock + 1000 > lastBlock ? lastBlock : toBlock + 1000;
+    toBlock = toBlock + 5000 > lastBlock ? lastBlock : toBlock + 5000;
   }
-
   return looped[0].args[0].toNumber();
 };
 

--- a/src/app/common/functions/web3Client.ts
+++ b/src/app/common/functions/web3Client.ts
@@ -19,10 +19,10 @@ import { fromDecimals, maximumUint256Value, toDecimals } from './utils';
 const ethereumTestnetProviderUrl =
   'https://rpc.tenderly.co/fork/6e7b39bd-7219-4b05-8f65-8ab837da4f11';
 const ethereumMainnetProviderUrl =
-  'https://eth-mainnet.g.alchemy.com/v2/BQ85p2q56v_fKcKachiDuBCdmpyNCWZr';
+'https://eth.llamarpc.com/';
 const ethereumProviderUrl =
   process.env.REACT_APP_NET === 'mainnet'
-    ? ethereumMainnetProviderUrl
+    ? process.env.REACT_APP_ETHEREUM_RPC
     : ethereumTestnetProviderUrl;
 
 const polygonTestnetProviderUrl = 'https://polygon-rpc.com/';
@@ -730,9 +730,7 @@ export const approve = async (
 };
 
 export const getReadOnlyProvider = chain => {
-  const providerUrl =
-    chain === EChain.ETHEREUM ? ethereumProviderUrl : polygonProviderUrl;
-  return new ethers.providers.JsonRpcProvider(providerUrl, 'any');
+  return new ethers.providers.JsonRpcProvider(chain === EChain.ETHEREUM ? ethereumProviderUrl : polygonProviderUrl, 'any');
 };
 
 export const callContract = async (
@@ -779,12 +777,10 @@ export const QueryFilter = async (
   const contract = new ethers.Contract(address, abi, readOnlyProvider);
 
   try {
-    const event = contract.filters[eventSignature].apply(null, params);
-
     const logs = await contract.queryFilter(
-      event,
+      contract.filters[eventSignature].apply(null, params),
       blockNumber,
-      toBlockNumber ? toBlockNumber : blockNumber,
+      toBlockNumber || blockNumber,
     );
 
     return logs;

--- a/src/app/common/state/boostFarm/useBoostFarm.ts
+++ b/src/app/common/state/boostFarm/useBoostFarm.ts
@@ -876,7 +876,6 @@ export const useBoostFarm = ({ id }) => {
     const loadFarmInfo = async () => {
       try {
         var startFirstTimer = performance.now()
-
         const lastHarvestDateTimestamp = await getLastHarvestDateTimestamp(
           selectedFarm.current?.farmAddress,
           selectedFarm.current?.chain,


### PR DESCRIPTION
### What I did:

1 - I changed the RPC to ethLlama, got down to 10s load time
2 - I remove redundant bindings
3 - I filter through 5k blocks instead of 1k, improves speed since async function gets called less