### PR TITLE
Change yearn api

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "engines": {
     "yarn": "1.22.19",
-    "node": "18.12.0",
+    "node": ">=18.12.0",
     "npm": "8.19.2"
   },
   "dependencies": {

--- a/src/app/common/functions/optimisedFarm.ts
+++ b/src/app/common/functions/optimisedFarm.ts
@@ -188,7 +188,7 @@ export const getUserOptimisedFarmDepositedAmount = async (
 };
 
 const optimisedYearnFarmInterestApiUrl =
-  'https://api.yearn.finance/v1/chains/10/vaults/all';
+  'https://api.yearn.fi/v1/chains/10/vaults/all';
 const optimisedBeefyFarmInterestApiUrl = 'https://api.beefy.finance/';
 
 const compoundingApy = (baseApy, rewardApy, fee, vaultPercentage) => {


### PR DESCRIPTION
ATM yearn's api is down because they have a dns issue with their main domain yearn.finance.

Once we check that their .fi is fine on staging, this is good to go to main