### PR TITLE
Move to new yearn api

### DIFF
--- a/src/app/common/functions/optimisedFarm.ts
+++ b/src/app/common/functions/optimisedFarm.ts
@@ -188,7 +188,7 @@ export const getUserOptimisedFarmDepositedAmount = async (
 };
 
 const optimisedYearnFarmInterestApiUrl =
-  'https://api.yearn.fi/v1/chains/10/vaults/all';
+  'https://ydaemon.yearn.fi/10/vaults/all';
 const optimisedBeefyFarmInterestApiUrl = 'https://api.beefy.finance/';
 
 const compoundingApy = (baseApy, rewardApy, fee, vaultPercentage) => {


### PR DESCRIPTION
https://ydaemon.yearn.farm/docs/routes

move to this new api after yearn suddenly deprecated their previous one.

Website is down until this is live